### PR TITLE
LargePage::Load/Store and BloomFilter speed up

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(
         main.cpp
         cm_sketch_benchmark.cpp
         tiny_lfu_cms_benchmark.cpp
+        large_page_benchmark.cpp
 )
 
 target_include_directories(

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(
         cm_sketch_benchmark.cpp
         tiny_lfu_cms_benchmark.cpp
         large_page_benchmark.cpp
+        bloom_filter_benchmark.cpp
 )
 
 target_include_directories(

--- a/benchmark/bloom_filter_benchmark.cpp
+++ b/benchmark/bloom_filter_benchmark.cpp
@@ -1,0 +1,40 @@
+#include <benchmark/benchmark.h>
+
+#include <bloom_filter.hpp>
+
+#include <random>
+
+static constexpr size_t kCapacity = 1024;
+
+static void BloomFilter_Add(benchmark::State& state) {
+  cache::BloomFilter<kCapacity> bf;
+  std::mt19937 rng;
+  for (auto _ : state) {
+    bf.Add(rng());
+  }
+}
+BENCHMARK(BloomFilter_Add);
+
+static void BloomFilter_Test(benchmark::State& state) {
+  cache::BloomFilter<kCapacity> bf;
+  std::mt19937 rng;
+  for (auto _ : state) {
+    bf.Test(rng());
+  }
+}
+BENCHMARK(BloomFilter_Test);
+
+/*
+Run on (16 X 4949.96 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x8)
+  L1 Instruction 32 KiB (x8)
+  L2 Unified 1024 KiB (x8)
+  L3 Unified 16384 KiB (x1)
+Load Average: 2.18, 1.66, 1.47
+-----------------------------------------------------------
+Benchmark                 Time             CPU   Iterations
+-----------------------------------------------------------
+BloomFilter_Add        1.75 ns         1.75 ns    392168096
+BloomFilter_Test       1.82 ns         1.81 ns    387862054
+*/

--- a/benchmark/large_page_benchmark.cpp
+++ b/benchmark/large_page_benchmark.cpp
@@ -15,21 +15,6 @@ static void LargePage_StoreLoad(benchmark::State& state) {
 BENCHMARK(LargePage_StoreLoad);
 
 /*
-2025-03-10T13:36:41+03:00
-Running ./build_release/benchmark/cache_benchmark
-Run on (16 X 5068.09 MHz CPU s)
-CPU Caches:
-  L1 Data 32 KiB (x8)
-  L1 Instruction 32 KiB (x8)
-  L2 Unified 1024 KiB (x8)
-  L3 Unified 16384 KiB (x1)
-Load Average: 1.31, 1.06, 1.30
---------------------------------------------------------------
-Benchmark                    Time             CPU   Iterations
---------------------------------------------------------------
-LargePage_StoreLoad    4614507 ns      4613506 ns          151
-
-2025-03-10T13:29:41+03:00
 Running ./build_release/benchmark/cache_benchmark
 Run on (16 X 5065.12 MHz CPU s)
 CPU Caches:

--- a/benchmark/large_page_benchmark.cpp
+++ b/benchmark/large_page_benchmark.cpp
@@ -1,0 +1,45 @@
+#include <benchmark/benchmark.h>
+
+#include <cache.hpp>
+
+static void LargePage_StoreLoad(benchmark::State& state) {
+  cache::TTinyLFU tiny_lfu;
+  cache::LargePage large_page{tiny_lfu};
+  std::ofstream out("/tmp/large_page.bin", std::ios::binary);
+  std::ifstream in("/tmp/large_page.bin", std::ios::binary);
+  for (auto _ : state) {
+    large_page.Store(out);
+    large_page.Load(in);
+  }
+}
+BENCHMARK(LargePage_StoreLoad);
+
+/*
+2025-03-10T13:36:41+03:00
+Running ./build_release/benchmark/cache_benchmark
+Run on (16 X 5068.09 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x8)
+  L1 Instruction 32 KiB (x8)
+  L2 Unified 1024 KiB (x8)
+  L3 Unified 16384 KiB (x1)
+Load Average: 1.31, 1.06, 1.30
+--------------------------------------------------------------
+Benchmark                    Time             CPU   Iterations
+--------------------------------------------------------------
+LargePage_StoreLoad    4614507 ns      4613506 ns          151
+
+2025-03-10T13:29:41+03:00
+Running ./build_release/benchmark/cache_benchmark
+Run on (16 X 5065.12 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x8)
+  L1 Instruction 32 KiB (x8)
+  L2 Unified 1024 KiB (x8)
+  L3 Unified 16384 KiB (x1)
+Load Average: 0.98, 1.42, 1.53
+--------------------------------------------------------------
+Benchmark                    Time             CPU   Iterations
+--------------------------------------------------------------
+LargePage_StoreLoad     649488 ns       608708 ns         1250
+*/

--- a/core/include/bloom_filter.hpp
+++ b/core/include/bloom_filter.hpp
@@ -3,27 +3,36 @@
 #include <bit>
 #include <cmath>
 #include <fstream>
-#include <vector>
 #include <cstdint>
 
 #include "utils.hpp"
 
+namespace cache {
+
+namespace detail {
+
+constexpr double kLog2 = 0.693147181;
+constexpr double kLogFalsePositiveRate = -4.605170186; // std::log(0.01)
+
+constexpr uint32_t CalcNumBits(uint32_t capacity) {
+    return std::max(1024U, std::bit_ceil(static_cast<uint32_t>(capacity * -kLogFalsePositiveRate / (kLog2 * kLog2))));
+}
+
+}  // namespace detail
+
+template <size_t Capacity>
 class BloomFilter final {
 public:
-    BloomFilter(int32_t capacity, double falsePositiveRate)
-        : num_bits(std::max(
-            1024U,
-            std::bit_ceil(static_cast<uint32_t>(capacity * -std::log(falsePositiveRate) / (std::log(2.0) * std::log(2.0)))))
-        ),
-        num_hash_func_(std::max(2U, static_cast<uint32_t>(0.7 * num_bits / capacity))),
-        data_((num_bits + 63) / 64, 0) {}
+    static constexpr auto kNumBits = detail::CalcNumBits(Capacity);
+    static constexpr auto kNumHashFunc = std::max(2U, static_cast<uint32_t>(0.7 * kNumBits / Capacity));
+    static constexpr auto kDataSize = (kNumBits + 63) / 64;
 
     bool Add(uint64_t key) noexcept {
         const auto h1 = static_cast<uint32_t>(key);
         const auto h2 = static_cast<uint32_t>(key >> 32);
         bool was_added = true;
-        for (uint32_t i = 0; i < num_hash_func_; i++) {
-            const auto bit = (h1 + (i * h2)) & (num_bits - 1);
+        for (uint32_t i = 0; i < kNumHashFunc; i++) {
+            const auto bit = (h1 + (i * h2)) & (kNumBits - 1);
             const auto mask = 1ULL << (bit % 64);
             auto& block = data_[bit / 64];
             const auto prev_bit_value = (block & mask) >> (bit % 64);
@@ -38,8 +47,8 @@ public:
         const auto h1 = static_cast<uint32_t>(key);
         const auto h2 = static_cast<uint32_t>(key >> 32);
         bool was_added = true;
-        for (uint32_t i = 0; i < num_hash_func_; i++) {
-            const auto bit = (h1 + (i * h2)) & (num_bits - 1);
+        for (uint32_t i = 0; i < kNumHashFunc; i++) {
+            const auto bit = (h1 + (i * h2)) & (kNumBits - 1);
             const auto mask = 1ULL << (bit % 64);
             const auto block = data_[bit / 64];
             was_added &= (block & mask) >> (bit % 64);
@@ -53,25 +62,21 @@ public:
     }
 
     void Load(std::ifstream& file) {
-        utils::BinaryRead(file, &num_bits, sizeof(num_bits));
-        utils::BinaryRead(file, &num_hash_func_, sizeof(num_hash_func_));
         utils::BinaryRead(file, data_.data(), data_.size() * sizeof(data_[0]));
     }
 
     void Store(std::ofstream& file) const {
-        utils::BinaryWrite(file, &num_bits, sizeof(num_bits));
-        utils::BinaryWrite(file, &num_hash_func_, sizeof(num_hash_func_));
         utils::BinaryWrite(file, data_.data(), data_.size() * sizeof(data_[0]));
     }
 
     bool operator==(const BloomFilter& other) const {
-        return num_bits == other.num_bits
-            && num_hash_func_ == other.num_hash_func_
+        return kNumBits == other.kNumBits
+            && kNumHashFunc == other.kNumHashFunc
             && data_ == other.data_;
     }
 
 private:
-    uint32_t num_bits; // size of bit vector in bits
-    uint32_t num_hash_func_; // distinct hash functions needed
-    std::vector<uint64_t> data_;
+    std::array<uint64_t, kDataSize> data_{};
 };
+
+}  // namespace cache

--- a/core/include/small_page_advanced.hpp
+++ b/core/include/small_page_advanced.hpp
@@ -45,8 +45,6 @@ public:
     }
 
     void Load(std::ifstream& file) {
-        tiny_lfu_.Load(file);
-
 #if USE_BF_FLAG
         bloom_filter_.Load(file);
 #endif
@@ -57,8 +55,6 @@ public:
     }
 
     void Store(std::ofstream& file) const {
-        tiny_lfu_.Store(file);
-
 #if USE_BF_FLAG
         bloom_filter_.Store(file);
 #endif

--- a/core/include/tiny_lfu_cms.hpp
+++ b/core/include/tiny_lfu_cms.hpp
@@ -121,7 +121,7 @@ class TinyLFU<T, SampleSize, NumCounters, true> final {
 
  private:
   CountMinSketch<NumCounters> sketch_;
-  BloomFilter door_keeper_{SampleSize, 0.01};
+  BloomFilter<SampleSize> door_keeper_;
   TGlobalCounter global_counter_{0};
 };
 

--- a/core/include/utils.hpp
+++ b/core/include/utils.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <array>
+#include <cstring>
 #include <fstream>
 
 namespace utils {
@@ -20,8 +21,16 @@ inline void BinaryWrite(std::ofstream& out, const void* data, size_t size) {
     out.write(reinterpret_cast<const char*>(data), size);
 }
 
+inline void BinaryWrite(char* buffer, const void* data, size_t size) noexcept {
+    std::memcpy(buffer, data, size);
+}
+
 inline void BinaryRead(std::ifstream& in, void* data, size_t size) {
     in.read(reinterpret_cast<char*>(data), size);
+}
+
+inline void BinaryRead(const char* buffer, void* data, size_t size) noexcept {
+    std::memcpy(data, buffer, size);
 }
 
 }  // namespace utils

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(
         bloom_filter_simple_test.cpp
         cm_sketch_test.cpp
         lru_test.cpp
+        large_page_test.cpp
 )
 
 target_include_directories(

--- a/test/bloom_filter_test.cpp
+++ b/test/bloom_filter_test.cpp
@@ -7,11 +7,12 @@
 
 namespace cache::test {
 
-TEST(BloomFilter, AddAndTest) {
-  const size_t capacity = 1000;
-  BloomFilter bf{capacity, 0.01};
+static constexpr size_t kCapacity = 1000;
 
-  for (size_t i = 0; i < capacity; ++i) {
+TEST(BloomFilter, AddAndTest) {
+  BloomFilter<kCapacity> bf;
+
+  for (size_t i = 0; i < kCapacity; ++i) {
     EXPECT_FALSE(bf.Test(i));
   }
 
@@ -27,7 +28,7 @@ TEST(BloomFilter, AddAndTest) {
 }
 
 TEST(BloomFilter, FillAndClear) {
-  BloomFilter bf{1000, 0.01};
+  BloomFilter<kCapacity> bf;
 
   const size_t num_keys = 42;
 
@@ -44,8 +45,8 @@ TEST(BloomFilter, FillAndClear) {
 }
 
 TEST(BloomFilter, SerializeDeserialize) {
-  BloomFilter bf{1000, 0.01};
-  BloomFilter bf_copy{1000, 0.01};
+  BloomFilter<kCapacity> bf;
+  BloomFilter<kCapacity> bf_copy;
 
   EXPECT_EQ(bf, bf_copy);
 

--- a/test/large_page_test.cpp
+++ b/test/large_page_test.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include <cache.hpp>
+
+namespace cache::test {
+
+using Key = uint32_t;
+using namespace std::chrono_literals;
+
+TEST(LargePage, Basics) {
+  TTinyLFU tiny_lfu;
+  LargePage large_page{tiny_lfu};
+
+  for (size_t i = 0; i < SMALL_PAGE_SIZE; ++i) {
+    EXPECT_FALSE(large_page.Get(i));
+    large_page.Update(i);
+    EXPECT_TRUE(large_page.Get(i));
+  }
+
+  large_page.Clear();
+  for (size_t i = 0; i < SMALL_PAGE_SIZE; ++i) {
+    EXPECT_FALSE(large_page.Get(i));
+  }
+}
+
+TEST(LargePage, SerializeDeserialize) {
+  TTinyLFU tiny_lfu;
+  LargePage large_page{tiny_lfu};
+
+  std::random_device rd;
+  const auto seed = rd();
+  std::cout << "Seed: " << seed << std::endl;
+  std::mt19937 gen(seed);
+
+  const auto NUM_KEYS = 20'000;
+  std::vector<uint32_t> keys;
+  keys.reserve(NUM_KEYS);
+  for (size_t i = 0; i < NUM_KEYS; ++i) {
+    const uint32_t key = gen();
+    keys.push_back(key);
+
+    if (!large_page.Get(key)) large_page.Update(key);
+  }
+
+  tiny_lfu.Clear();
+  LargePage large_page_copy{tiny_lfu};
+  for (auto key : keys) {
+    if (!large_page_copy.Get(key)) large_page_copy.Update(key);
+  }
+
+  {
+    std::ofstream file("/tmp/large_page.bin", std::ios::binary);
+    large_page.Store(file);
+  }
+  {
+    large_page.Clear();
+    std::ifstream file("/tmp/large_page.bin", std::ios::binary);
+    large_page.Load(file);
+  }
+
+  EXPECT_TRUE(large_page == large_page_copy);
+}
+
+}  // namespace cache::test


### PR DESCRIPTION
### LargePage
Benchmark: https://github.com/mnink275/effective_stream_cache/blob/ink/benchmark/large_page_benchmark.cpp

```
BEFORE:
Run on (16 X 5068.83 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 3.84, 1.99, 1.50
--------------------------------------------------------------
Benchmark                    Time             CPU   Iterations
--------------------------------------------------------------
LargePage_StoreLoad    4719521 ns      4715877 ns          152

AFTER:
Run on (16 X 4920.93 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 1.25, 1.63, 1.43
--------------------------------------------------------------
Benchmark                    Time             CPU   Iterations
--------------------------------------------------------------
LargePage_StoreLoad     606650 ns       606178 ns         1150
```

### BloomFilter
Benchmark: https://github.com/mnink275/effective_stream_cache/blob/ink/benchmark/bloom_filter_benchmark.cpp

```
BEFORE:
Run on (16 X 5064.85 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 1.46, 1.46, 1.40
-----------------------------------------------------------
Benchmark                 Time             CPU   Iterations
-----------------------------------------------------------
BloomFilter_Add        7.76 ns         7.76 ns     78515846
BloomFilter_Test       1.71 ns         1.71 ns    394182553

AFTER:
Run on (16 X 4949.96 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 2.18, 1.66, 1.47
-----------------------------------------------------------
Benchmark                 Time             CPU   Iterations
-----------------------------------------------------------
BloomFilter_Add        1.75 ns         1.75 ns    392168096
BloomFilter_Test       1.82 ns         1.81 ns    387862054
```
